### PR TITLE
feat: 커스텀 에러 처리 구현 

### DIFF
--- a/src/main/java/backend/sumnail/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/controller/HashtagController.java
@@ -9,17 +9,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/v1/hashtags")
 @RequiredArgsConstructor
 public class HashtagController {
 
     private final HashtagService hashtagService;
+
     @GetMapping("")
-    public ResponseEntity<HashtagFindAllResponse> findAllHashtags(){
-        HashtagFindAllResponse response=hashtagService.findAllHashtag();
+    public ResponseEntity<HashtagFindAllResponse> findAllHashtags() {
+        HashtagFindAllResponse response = hashtagService.findAllHashtag();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/backend/sumnail/domain/hashtag/controller/dto/response/HashtagFindAllResponse.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/controller/dto/response/HashtagFindAllResponse.java
@@ -1,9 +1,8 @@
 package backend.sumnail.domain.hashtag.controller.dto.response;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagJpaRepository.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagJpaRepository.java
@@ -1,10 +1,10 @@
 package backend.sumnail.domain.hashtag.repository;
 
 import backend.sumnail.domain.hashtag.entity.Hashtag;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HashtagJpaRepository extends JpaRepository<Hashtag,Long> {
+public interface HashtagJpaRepository extends JpaRepository<Hashtag, Long> {
 
     Optional<Hashtag> findByHashtagName(String hashtagName);
 

--- a/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -1,6 +1,8 @@
 package backend.sumnail.domain.hashtag.repository;
 
 import backend.sumnail.domain.hashtag.entity.Hashtag;
+import backend.sumnail.global.exception.CustomException;
+import backend.sumnail.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
@@ -25,7 +27,6 @@ public class HashtagRepositoryImpl implements HashtagRepository{
     @Override
     public Hashtag getById(Long id) {
         return hashtagJpaRepository.findById(id)
-                // TODO 커스텀 에러 만든 후 수정
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 해시태그 id 입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_HASHTAG));
     }
 }

--- a/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -3,14 +3,14 @@ package backend.sumnail.domain.hashtag.repository;
 import backend.sumnail.domain.hashtag.entity.Hashtag;
 import backend.sumnail.global.exception.CustomException;
 import backend.sumnail.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class HashtagRepositoryImpl implements HashtagRepository{
+public class HashtagRepositoryImpl implements HashtagRepository {
 
     private final HashtagJpaRepository hashtagJpaRepository;
 

--- a/src/main/java/backend/sumnail/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/service/HashtagService.java
@@ -5,6 +5,8 @@ import backend.sumnail.domain.hashtag.entity.Hashtag;
 import backend.sumnail.domain.hashtag.repository.HashtagRepository;
 import backend.sumnail.domain.nail_shop.entity.NailShop;
 import backend.sumnail.domain.nail_shop_hashtag.service.NailShopHashtagService;
+import backend.sumnail.global.exception.CustomException;
+import backend.sumnail.global.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +42,7 @@ public class HashtagService {
                 .toList();
 
         if (hashtags.size() > Hashtag.MAX_HASHTAG_COUNT) {
-            // TODO 커스텀 에러 만든 후 수정
-            throw new RuntimeException("해시태그의 최대개수는 3개입니다.");
+            throw new CustomException(ErrorCode.EXCEEDED_MAX_HASHTAG);
         }
 
         return hashtags;

--- a/src/main/java/backend/sumnail/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/backend/sumnail/domain/hashtag/service/HashtagService.java
@@ -21,15 +21,15 @@ public class HashtagService {
     private final HashtagRepository hashtagRepository;
     private final NailShopHashtagService nailShopHashtagService;
 
-    public HashtagFindAllResponse findAllHashtag(){
-        List<String> list=new ArrayList<>();
-        List<Hashtag> hashtags=hashtagRepository.findAll();
+    public HashtagFindAllResponse findAllHashtag() {
+        List<String> list = new ArrayList<>();
+        List<Hashtag> hashtags = hashtagRepository.findAll();
 
-        for (Hashtag hashtag:hashtags
+        for (Hashtag hashtag : hashtags
         ) {
             list.add(hashtag.getHashtagName());
         }
-        HashtagFindAllResponse response=HashtagFindAllResponse.builder()
+        HashtagFindAllResponse response = HashtagFindAllResponse.builder()
                 .hashtags(list)
                 .build();
         return response;

--- a/src/main/java/backend/sumnail/domain/nail_shop/controller/NailShopController.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/controller/NailShopController.java
@@ -3,13 +3,15 @@ package backend.sumnail.domain.nail_shop.controller;
 import backend.sumnail.domain.nail_shop.controller.dto.response.NailShopFindAllResponse;
 import backend.sumnail.domain.nail_shop.controller.dto.response.NailShopFindOneResponse;
 import backend.sumnail.domain.nail_shop.service.NailShopService;
-import jakarta.websocket.server.PathParam;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/nail-shops")
@@ -18,21 +20,22 @@ public class NailShopController {
     private final NailShopService nailShopService;
 
     @GetMapping("")
-    public ResponseEntity<List<NailShopFindAllResponse>> getAllShops(){
-        List<NailShopFindAllResponse> response=nailShopService.findAllShop();
+    public ResponseEntity<List<NailShopFindAllResponse>> getAllShops() {
+        List<NailShopFindAllResponse> response = nailShopService.findAllShop();
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<NailShopFindAllResponse>> searchShops(@RequestParam String hashtags, @RequestParam String station){
-        List<NailShopFindAllResponse> response=nailShopService.searchNailShop(station,hashtags);
+    public ResponseEntity<List<NailShopFindAllResponse>> searchShops(@RequestParam String hashtags,
+                                                                     @RequestParam String station) {
+        List<NailShopFindAllResponse> response = nailShopService.searchNailShop(station, hashtags);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @GetMapping("/{nailShopId}")
-    public ResponseEntity<NailShopFindOneResponse> searchShopById(@PathVariable Long nailShopId){
-        NailShopFindOneResponse response=nailShopService.findNailShopById(nailShopId);
+    public ResponseEntity<NailShopFindOneResponse> searchShopById(@PathVariable Long nailShopId) {
+        NailShopFindOneResponse response = nailShopService.findNailShopById(nailShopId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/backend/sumnail/domain/nail_shop/controller/dto/response/NailShopFindAllResponse.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/controller/dto/response/NailShopFindAllResponse.java
@@ -1,10 +1,8 @@
 package backend.sumnail.domain.nail_shop.controller.dto.response;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-
-import java.util.List;
 
 @Builder
 @Getter

--- a/src/main/java/backend/sumnail/domain/nail_shop/controller/dto/response/NailShopFindOneResponse.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/controller/dto/response/NailShopFindOneResponse.java
@@ -1,9 +1,8 @@
 package backend.sumnail.domain.nail_shop.controller.dto.response;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Builder
 @Getter

--- a/src/main/java/backend/sumnail/domain/nail_shop/entity/NailShop.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/entity/NailShop.java
@@ -3,12 +3,17 @@ package backend.sumnail.domain.nail_shop.entity;
 import backend.sumnail.domain.nail_shop_hashtag.entity.NailShopHashtag;
 import backend.sumnail.domain.nail_shop_station.entity.NailShopStation;
 import backend.sumnail.global.util.StringListConverter;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 
 @Entity
@@ -16,15 +21,15 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NailShop {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="nail_shop_id")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "nail_shop_id")
     private Long id;
 
     @Column(name = "nail_shop_name")
     private String name;
 
     private String location;
-
 
 ////    @Convert(converter = PointConverter.class)
 //    @Column(columnDefinition = "Geometry")
@@ -47,10 +52,10 @@ public class NailShop {
     @Column(name = "monthly_nail_instagram_link")
     private String monthlyNailLink;
 
-    @Column(name="monthly_nail_minimum_price")
+    @Column(name = "monthly_nail_minimum_price")
     private Long minimumPrice;
 
-    @Column(name="monthly_nail_maximum_price")
+    @Column(name = "monthly_nail_maximum_price")
     private Long maximumPrice;
 
     private String titleImage;

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopJpaRepository.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopJpaRepository.java
@@ -1,12 +1,12 @@
 package backend.sumnail.domain.nail_shop.repository;
 
 import backend.sumnail.domain.nail_shop.entity.NailShop;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface NailShopJpaRepository extends JpaRepository<NailShop,Long> {
+public interface NailShopJpaRepository extends JpaRepository<NailShop, Long> {
 
     @Query("SELECT DISTINCT ns FROM NailShop ns " +
             "LEFT JOIN ns.hashtags nh " +
@@ -14,8 +14,8 @@ public interface NailShopJpaRepository extends JpaRepository<NailShop,Long> {
             "WHERE (COALESCE(:hashtagName, '') = '' OR nh.hashtag.hashtagName = :hashtagName) " +
             "AND (COALESCE(:stationName, '') = '' OR s.station.stationName = :stationName)")
     List<NailShop> findNailShopsByHashtagAndStation(
-             String stationName,
-             String hashtagName
+            String stationName,
+            String hashtagName
     );
 
     Optional<NailShop> findById(Long id);

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
@@ -3,23 +3,24 @@ package backend.sumnail.domain.nail_shop.repository;
 import backend.sumnail.domain.nail_shop.entity.NailShop;
 import backend.sumnail.global.exception.CustomException;
 import backend.sumnail.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class NailShopRepositoryImpl implements NailShopRepository{
+public class NailShopRepositoryImpl implements NailShopRepository {
     private final NailShopJpaRepository nailShopJpaRepository;
+
     @Override
     public List<NailShop> findAll() {
         return nailShopJpaRepository.findAll();
     }
 
     @Override
-    public List<NailShop> findNailShopsByHashtagAndStation(String stationName, String hashtagName){
-        return nailShopJpaRepository.findNailShopsByHashtagAndStation(stationName,hashtagName);
+    public List<NailShop> findNailShopsByHashtagAndStation(String stationName, String hashtagName) {
+        return nailShopJpaRepository.findNailShopsByHashtagAndStation(stationName, hashtagName);
     }
 
     @Override

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
@@ -1,6 +1,8 @@
 package backend.sumnail.domain.nail_shop.repository;
 
 import backend.sumnail.domain.nail_shop.entity.NailShop;
+import backend.sumnail.global.exception.CustomException;
+import backend.sumnail.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
@@ -28,7 +30,6 @@ public class NailShopRepositoryImpl implements NailShopRepository{
     @Override
     public NailShop getById(long nailShopId) {
         return nailShopJpaRepository.findById(nailShopId)
-                // TODO 커스텀 에러 만든 후 수정
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 네일샵입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_NAIL_SHOP));
     }
 }

--- a/src/main/java/backend/sumnail/domain/nail_shop/service/NailShopService.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/service/NailShopService.java
@@ -9,12 +9,11 @@ import backend.sumnail.domain.nail_shop.entity.NailShop;
 import backend.sumnail.domain.nail_shop.repository.NailShopRepository;
 import backend.sumnail.domain.nail_shop_hashtag.entity.NailShopHashtag;
 import backend.sumnail.domain.user_nail_shop.entity.UserNailShop;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +22,7 @@ public class NailShopService {
 
     private final NailShopRepository nailShopRepository;
     private final HashtagService hashtagService;
+
     public List<NailShopFindAllResponse> findAllShop() {
 
         List<NailShopFindAllResponse> response = new ArrayList<>();
@@ -49,17 +49,16 @@ public class NailShopService {
 
     public List<NailShopFindAllResponse> searchNailShop(String stationName, String hashtagName) {
         List<NailShopFindAllResponse> response = new ArrayList<>();
-        if(stationName.isEmpty()){
-            stationName="";
+        if (stationName.isEmpty()) {
+            stationName = "";
         }
-        List<NailShop> nailShops= nailShopRepository.findNailShopsByHashtagAndStation(stationName,hashtagName);
-        for (NailShop nailShop : nailShops
-        ) {
+        List<NailShop> nailShops = nailShopRepository.findNailShopsByHashtagAndStation(stationName, hashtagName);
+        for (NailShop nailShop : nailShops) {
             List<String> hashtags = new ArrayList<>();
-            for (NailShopHashtag nailShopHashtag : nailShop.getHashtags()
-            ) {
+            for (NailShopHashtag nailShopHashtag : nailShop.getHashtags()) {
                 hashtags.add(nailShopHashtag.getHashtag().getHashtagName());
             }
+
             NailShopFindAllResponse nailShopFindAllResponse = NailShopFindAllResponse.builder()
                     .nailShopId(nailShop.getId())
                     .nailShopName(nailShop.getName())
@@ -72,16 +71,16 @@ public class NailShopService {
         return response;
     }
 
-    public NailShopFindOneResponse findNailShopById(Long id){
-        NailShop nailShop=nailShopRepository.findById(id).get();
+    public NailShopFindOneResponse findNailShopById(Long id) {
 
-//        NailShop nailShop=nailShopRepository.findById(id).orElseThrow(()->new RuntimeException());
-        List<String> hashtags= new ArrayList<>();
-        for (NailShopHashtag nailShopHashtag : nailShop.getHashtags()
-        ) {
+        NailShop nailShop = nailShopRepository.getById(id);
+
+        List<String> hashtags = new ArrayList<>();
+        for (NailShopHashtag nailShopHashtag : nailShop.getHashtags()) {
             hashtags.add(nailShopHashtag.getHashtag().getHashtagName());
         }
-        NailShopFindOneResponse nailShopFindOneResponse=NailShopFindOneResponse.builder()
+
+        NailShopFindOneResponse nailShopFindOneResponse = NailShopFindOneResponse.builder()
                 .nailShopId(nailShop.getId())
                 .nailShopName(nailShop.getName())
                 .detailImages(nailShop.getDetailImages())

--- a/src/main/java/backend/sumnail/domain/station/controller/StationController.java
+++ b/src/main/java/backend/sumnail/domain/station/controller/StationController.java
@@ -2,6 +2,7 @@ package backend.sumnail.domain.station.controller;
 
 import backend.sumnail.domain.station.controller.dto.response.StationFindAllResponse;
 import backend.sumnail.domain.station.service.StationService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,17 +11,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/v1/stations")
 @RequiredArgsConstructor
 public class StationController {
 
     private final StationService stationService;
+
     @GetMapping("")
-    public ResponseEntity<List<StationFindAllResponse>> findStationByKeywords(@RequestParam String keyword){
-        List<StationFindAllResponse> response=stationService.findStations(keyword);
+    public ResponseEntity<List<StationFindAllResponse>> findStationByKeywords(@RequestParam String keyword) {
+        List<StationFindAllResponse> response = stationService.findStations(keyword);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/backend/sumnail/domain/station/repository/StationJpaRepository.java
+++ b/src/main/java/backend/sumnail/domain/station/repository/StationJpaRepository.java
@@ -1,13 +1,11 @@
 package backend.sumnail.domain.station.repository;
 
 import backend.sumnail.domain.station.entity.Station;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StationJpaRepository extends JpaRepository<Station, Long>
-{
+public interface StationJpaRepository extends JpaRepository<Station, Long> {
     Optional<Station> findByStationName(String stationName);
 
     List<Station> findByStationNameContaining(String stationName);

--- a/src/main/java/backend/sumnail/domain/station/repository/StationRepository.java
+++ b/src/main/java/backend/sumnail/domain/station/repository/StationRepository.java
@@ -1,7 +1,6 @@
 package backend.sumnail.domain.station.repository;
 
 import backend.sumnail.domain.station.entity.Station;
-
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/backend/sumnail/domain/station/repository/StationRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/station/repository/StationRepositoryImpl.java
@@ -1,17 +1,17 @@
 package backend.sumnail.domain.station.repository;
 
 import backend.sumnail.domain.station.entity.Station;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 @RequiredArgsConstructor
-public class StationRepositoryImpl implements StationRepository{
+public class StationRepositoryImpl implements StationRepository {
 
     private final StationJpaRepository stationJpaRepository;
+
     @Override
     public Optional<Station> findByStationName(String stationName) {
         return stationJpaRepository.findByStationName(stationName);

--- a/src/main/java/backend/sumnail/domain/station/service/StationService.java
+++ b/src/main/java/backend/sumnail/domain/station/service/StationService.java
@@ -3,12 +3,11 @@ package backend.sumnail.domain.station.service;
 import backend.sumnail.domain.station.controller.dto.response.StationFindAllResponse;
 import backend.sumnail.domain.station.entity.Station;
 import backend.sumnail.domain.station.repository.StationRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,14 +15,15 @@ import java.util.List;
 public class StationService {
 
     private final StationRepository stationRepository;
-    public List<StationFindAllResponse> findStations(String keywords){
-        List<Station> stations=stationRepository.findByStationNameContaining(keywords);
 
-        List<StationFindAllResponse> responses=new ArrayList<>();
+    public List<StationFindAllResponse> findStations(String keywords) {
+        List<Station> stations = stationRepository.findByStationNameContaining(keywords);
 
-        for (Station station:stations
-             ) {
-            StationFindAllResponse stationFindAllResponse=StationFindAllResponse.builder()
+        List<StationFindAllResponse> responses = new ArrayList<>();
+
+        for (Station station : stations
+        ) {
+            StationFindAllResponse stationFindAllResponse = StationFindAllResponse.builder()
                     .stationLine(station.getLine())
                     .stationName(station.getStationName())
                     .build();

--- a/src/main/java/backend/sumnail/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/user/repository/UserRepositoryImpl.java
@@ -1,6 +1,8 @@
 package backend.sumnail.domain.user.repository;
 
 import backend.sumnail.domain.user.entity.User;
+import backend.sumnail.global.exception.CustomException;
+import backend.sumnail.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +14,6 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public User getById(long id) {
         return userJpaRepository.findById(id)
-                // TODO 커스텀 에러 만든 후 수정
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
     }
 }

--- a/src/main/java/backend/sumnail/domain/user_nail_shop/service/UserNailShopService.java
+++ b/src/main/java/backend/sumnail/domain/user_nail_shop/service/UserNailShopService.java
@@ -4,6 +4,8 @@ import backend.sumnail.domain.nail_shop.entity.NailShop;
 import backend.sumnail.domain.user.entity.User;
 import backend.sumnail.domain.user_nail_shop.entity.UserNailShop;
 import backend.sumnail.domain.user_nail_shop.repository.UserNailShopRepository;
+import backend.sumnail.global.exception.CustomException;
+import backend.sumnail.global.exception.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,15 +35,13 @@ public class UserNailShopService {
     private void throwIfNailShopAlreadySaved(User user, NailShop nailShop) {
         userNailShopRepository.findByUserAndNailShop(user, nailShop)
                 .ifPresent((userNailShop) -> {
-                    // TODO 커스텀 에러 만든 후 수정
-                    throw new RuntimeException("이미 저장한 네일샵입니다");
+                    throw new CustomException(ErrorCode.ALREADY_SAVED_NAIL_SHOP);
                 });
     }
 
     private void throwIfNailShopNotSaved(User user, NailShop nailShop) {
         userNailShopRepository.findByUserAndNailShop(user, nailShop)
-                // TODO 커스텀 에러 만든 후 수정
-                .orElseThrow(() -> new RuntimeException("저장하지 않은 네일샵입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SAVED_NAIL_SHOP));
     }
 
 

--- a/src/main/java/backend/sumnail/global/exception/CustomException.java
+++ b/src/main/java/backend/sumnail/global/exception/CustomException.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
+
     public CustomException(ErrorCode errorCode) {
         super(errorCode.getError());
         this.errorCode = errorCode;

--- a/src/main/java/backend/sumnail/global/exception/CustomException.java
+++ b/src/main/java/backend/sumnail/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package backend.sumnail.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getError());
+        this.errorCode = errorCode;
+    }
+
+}
+

--- a/src/main/java/backend/sumnail/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/backend/sumnail/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,33 @@
+package backend.sumnail.global.exception;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+    // 일반 에러
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ErrorResponse.toResponseEntity(e);
+    }
+
+    // bean validation 관련 에러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        FieldError fieldError = e.getFieldError();
+
+        if (Objects.isNull(fieldError)) { // 일반적으로는 fieldError가 null이 될 수 없지만, 예외 케이스 처리 용도.
+            return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, fieldError);
+    }
+}

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -24,9 +24,10 @@ public enum ErrorCode {
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증되지 않은 토큰입니다."),
 
+    // NailShop 예외
+    NOT_FOUND_NAIL_SHOP(HttpStatus.NOT_FOUND, "해당 네일샵 찾을 수 없습니다.")
 
    ;
-
     private final HttpStatus status;
     private final String error;
 }

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     // User 예외
     UNAUTHORIZED_ID(HttpStatus.UNAUTHORIZED, "아이디가 틀립니다."),
     UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 틀립니다."),
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     EXIST_MEMBER_PREFERRED_FEED(HttpStatus.CONFLICT, "이미 좋아요한 피드입니다."),
 
 
@@ -23,6 +23,7 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증되지 않은 토큰입니다."),
+
 
    ;
 

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
     UNAUTHORIZED_ID(HttpStatus.UNAUTHORIZED, "아이디가 틀립니다."),
     UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 틀립니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
-    EXIST_MEMBER_PREFERRED_FEED(HttpStatus.CONFLICT, "이미 좋아요한 피드입니다."),
+    ALREADY_SAVED_NAIL_SHOP(HttpStatus.CONFLICT, "이미 저장한 네일샵입니다."),
+    NOT_FOUND_SAVED_NAIL_SHOP(HttpStatus.NOT_FOUND,"저장한 적 없는 네일샵입니다."),
 
 
     // Token 예외
@@ -29,6 +30,7 @@ public enum ErrorCode {
 
     // HashTag 예외
     NOT_FOUND_HASHTAG(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다."),
+    EXCEEDED_MAX_HASHTAG(HttpStatus.BAD_REQUEST,"해시태그의 최대 갯수를 초과합니다."),
    ;
 
     private final HttpStatus status;

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 틀립니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     ALREADY_SAVED_NAIL_SHOP(HttpStatus.CONFLICT, "이미 저장한 네일샵입니다."),
-    NOT_FOUND_SAVED_NAIL_SHOP(HttpStatus.NOT_FOUND,"저장한 적 없는 네일샵입니다."),
+    NOT_FOUND_SAVED_NAIL_SHOP(HttpStatus.NOT_FOUND, "저장한 적 없는 네일샵입니다."),
 
 
     // Token 예외
@@ -30,8 +30,8 @@ public enum ErrorCode {
 
     // HashTag 예외
     NOT_FOUND_HASHTAG(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다."),
-    EXCEEDED_MAX_HASHTAG(HttpStatus.BAD_REQUEST,"해시태그의 최대 갯수를 초과합니다."),
-   ;
+    EXCEEDED_MAX_HASHTAG(HttpStatus.BAD_REQUEST, "해시태그의 최대 갯수를 초과합니다."),
+    ;
 
     private final HttpStatus status;
     private final String error;

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -25,9 +25,12 @@ public enum ErrorCode {
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증되지 않은 토큰입니다."),
 
     // NailShop 예외
-    NOT_FOUND_NAIL_SHOP(HttpStatus.NOT_FOUND, "해당 네일샵 찾을 수 없습니다.")
+    NOT_FOUND_NAIL_SHOP(HttpStatus.NOT_FOUND, "해당 네일샵 찾을 수 없습니다."),
 
+    // HashTag 예외
+    NOT_FOUND_HASHTAG(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다."),
    ;
+
     private final HttpStatus status;
     private final String error;
 }

--- a/src/main/java/backend/sumnail/global/exception/ErrorCode.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package backend.sumnail.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 공통 예외
+    BAD_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_VALID_URI(HttpStatus.BAD_REQUEST, "유효한 경로로 요청해주세요."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // User 예외
+    UNAUTHORIZED_ID(HttpStatus.UNAUTHORIZED, "아이디가 틀립니다."),
+    UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 틀립니다."),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    EXIST_MEMBER_PREFERRED_FEED(HttpStatus.CONFLICT, "이미 좋아요한 피드입니다."),
+
+
+    // Token 예외
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증되지 않은 토큰입니다."),
+
+   ;
+
+    private final HttpStatus status;
+    private final String error;
+}

--- a/src/main/java/backend/sumnail/global/exception/ErrorResponse.java
+++ b/src/main/java/backend/sumnail/global/exception/ErrorResponse.java
@@ -1,0 +1,51 @@
+package backend.sumnail.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String status;
+    private final String error;
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(
+                        ErrorResponse.builder()
+                                .status(errorCode.getStatus().name())
+                                .error(errorCode.getError())
+                                .build()
+                );
+
+    }
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(HttpStatus status, FieldError fieldError) {
+        return ResponseEntity
+                .status(status)
+                .body(
+                        ErrorResponse.builder()
+                                .status(status.name())
+                                .error(fieldError.getDefaultMessage())
+                                .build()
+                );
+    }
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(HttpStatus status) {
+        return ResponseEntity
+                .status(status)
+                .body(
+                        ErrorResponse.builder()
+                                .status(status.name())
+                                .build()
+                );
+    }
+
+
+}

--- a/src/main/java/backend/sumnail/global/util/PointConverter.java
+++ b/src/main/java/backend/sumnail/global/util/PointConverter.java
@@ -2,7 +2,6 @@ package backend.sumnail.global.util;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-
 import java.awt.geom.Point2D;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/src/main/java/backend/sumnail/global/util/StringListConverter.java
+++ b/src/main/java/backend/sumnail/global/util/StringListConverter.java
@@ -2,7 +2,6 @@ package backend.sumnail.global.util;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,7 +18,7 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
     @Override
     public List<String> convertToEntityAttribute(String string) {
 
-        if(string==null){
+        if (string == null) {
             return new ArrayList<>();
         }
         return Arrays.asList(string.split(SPLIT_CHAR));


### PR DESCRIPTION
## 🌱 관련 이슈

- close #40

## 📌 작업 내용
-  CustomException을 이용해 전역 에러 처리를 구현했습니다.
-  각 domain 별 service에서 에러 처리가 필요한 부분에 customException을 추가했습니다.

## 🧪 테스트 방법
- 포스트맨으로 4XX 에러 확인

## ✅ 궁금한 점 & 리뷰 포인트
- 이후 에러 메시지의 종류가 많아진다면 각 도메인 별로 Exception을 처리하는 구조로 변경하면 될 것 같습니다.


