### PR TITLE
feat: 검색 완료 및 검색 기록 API 구현, CORS 세팅

### DIFF
--- a/src/main/java/backend/sumnail/domain/nail_shop/controller/NailShopController.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/controller/NailShopController.java
@@ -28,9 +28,6 @@ public class NailShopController {
     @GetMapping("search")
     public ResponseEntity<List<NailShopFindAllResponse>> searchShops(@RequestParam String hashtags, @RequestParam String station){
         List<NailShopFindAllResponse> response=nailShopService.searchNailShop(station,hashtags);
-        if(!response.isEmpty()) {
-            recentSearchService.addRecentSearch(station, 1);
-        }//JWT 토큰으로 userId 받아와야함
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopJpaRepository.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopJpaRepository.java
@@ -18,5 +18,15 @@ public interface NailShopJpaRepository extends JpaRepository<NailShop, Long> {
             String hashtagName
     );
 
+    @Query("SELECT DISTINCT ns FROM NailShop ns " +
+            "LEFT JOIN ns.hashtags nh " +
+            "WHERE (COALESCE(:hashtagName, '') = '' OR nh.hashtag.hashtagName = :hashtagName)")
+    List<NailShop> findNailShopByHashtag(String hashtagName);
+
+    @Query("SELECT DISTINCT ns FROM NailShop ns " +
+            "LEFT JOIN ns.stations s " +
+            "WHERE (COALESCE(:stationName, '') = '' OR s.station.stationName = :stationName)")
+    List<NailShop> findNailShopByStation(String stationName);
+
     Optional<NailShop> findById(Long id);
 }

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepository.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepository.java
@@ -13,4 +13,8 @@ public interface NailShopRepository {
     Optional<NailShop> findById(Long id);
 
     NailShop getById(long id);
+
+    List<NailShop> findNailShopByHashtag(String hashtagName);
+
+    List<NailShop> findNailShopByStation(String stationName);
 }

--- a/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/repository/NailShopRepositoryImpl.java
@@ -33,4 +33,14 @@ public class NailShopRepositoryImpl implements NailShopRepository {
         return nailShopJpaRepository.findById(nailShopId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_NAIL_SHOP));
     }
+
+    @Override
+    public List<NailShop> findNailShopByHashtag(String hashtagName) {
+        return nailShopJpaRepository.findNailShopByHashtag(hashtagName);
+    }
+
+    @Override
+    public List<NailShop> findNailShopByStation(String stationName) {
+        return nailShopJpaRepository.findNailShopByStation(stationName);
+    }
 }

--- a/src/main/java/backend/sumnail/domain/nail_shop/service/NailShopService.java
+++ b/src/main/java/backend/sumnail/domain/nail_shop/service/NailShopService.java
@@ -31,10 +31,19 @@ public class NailShopService {
     }
 
     public List<NailShopFindAllResponse> searchNailShop(String stationName, String hashtagName) {
-        if(stationName.isEmpty()){
-            stationName="";
+        List<NailShop> nailShops;
+        if(stationName.isEmpty() && hashtagName.isEmpty()){
+            nailShops = nailShopRepository.findAll();
         }
-        List<NailShop> nailShops= nailShopRepository.findNailShopsByHashtagAndStation(stationName,hashtagName);
+        else if(stationName.isEmpty()){
+            nailShops = nailShopRepository.findNailShopByHashtag(hashtagName);
+        }
+        else if(hashtagName.isEmpty()){
+            nailShops = nailShopRepository.findNailShopByStation(stationName);
+        }
+        else{
+            nailShops = nailShopRepository.findNailShopsByHashtagAndStation(stationName, hashtagName);
+        }
         List<NailShopFindAllResponse> response = nailShops
                 .stream()
                 .map(NailShop->NailShopFindAllResponse.from(NailShop))

--- a/src/main/java/backend/sumnail/domain/user/controller/dto/UserController.java
+++ b/src/main/java/backend/sumnail/domain/user/controller/dto/UserController.java
@@ -1,5 +1,7 @@
 package backend.sumnail.domain.user.controller.dto;
 
+import backend.sumnail.domain.recentsearch.service.RecentSearchService;
+import backend.sumnail.domain.user.controller.dto.request.RecentSearchSaveRequest;
 import backend.sumnail.domain.user.controller.dto.response.UserFindNailShopResponse;
 import backend.sumnail.domain.user.controller.dto.response.UserFindResponse;
 import backend.sumnail.domain.user.controller.dto.response.UserFindSearchStationsResponse;
@@ -8,12 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("v1/user")
@@ -21,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
-
+    private final RecentSearchService recentSearchService;
     // TODO 테스트 용 userId 1 번 사용중
 
     /**
@@ -77,6 +74,14 @@ public class UserController {
         userService.deleteSearchStationsUser(1);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
-
+    /**
+     * 지하철 역 검색 기록 추가
+     */
+    @PostMapping("search-station-history")
+    public ResponseEntity<Void> saveSearchStationsUser(@RequestBody RecentSearchSaveRequest request) {
+        recentSearchService.addRecentSearch(request.getStationName(), 1);
+        //jwt 인증 구현 필요
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 
 }

--- a/src/main/java/backend/sumnail/domain/user/controller/dto/request/RecentSearchSaveRequest.java
+++ b/src/main/java/backend/sumnail/domain/user/controller/dto/request/RecentSearchSaveRequest.java
@@ -1,0 +1,10 @@
+package backend.sumnail.domain.user.controller.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class RecentSearchSaveRequest {
+    private String stationName;
+}

--- a/src/main/java/backend/sumnail/domain/user/service/UserService.java
+++ b/src/main/java/backend/sumnail/domain/user/service/UserService.java
@@ -12,6 +12,10 @@ import backend.sumnail.domain.user.entity.User;
 import backend.sumnail.domain.user.repository.UserRepository;
 import backend.sumnail.domain.user_nail_shop.entity.UserNailShop;
 import backend.sumnail.domain.user_nail_shop.service.UserNailShopService;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,6 +65,8 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserFindSearchStationsResponse findSearchStationsUser(long userId) {
         List<RecentSearch> recentSearches = recentSearchService.findByUserId(userId);
+        Collections.sort(recentSearches, (a, b) -> b.getDateTime().compareTo(a.getDateTime()));
+        recentSearches=recentSearches.subList(0,Math.min(recentSearches.size(),3));
         return UserFindSearchStationsResponse.from(recentSearches);
     }
 

--- a/src/main/java/backend/sumnail/domain/user/service/UserService.java
+++ b/src/main/java/backend/sumnail/domain/user/service/UserService.java
@@ -16,6 +16,7 @@ import backend.sumnail.domain.user_nail_shop.service.UserNailShopService;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -65,9 +66,11 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserFindSearchStationsResponse findSearchStationsUser(long userId) {
         List<RecentSearch> recentSearches = recentSearchService.findByUserId(userId);
-        Collections.sort(recentSearches, (a, b) -> b.getDateTime().compareTo(a.getDateTime()));
-        recentSearches=recentSearches.subList(0,Math.min(recentSearches.size(),3));
-        return UserFindSearchStationsResponse.from(recentSearches);
+        List<RecentSearch> limitedRecentSearches= recentSearches.stream()
+                .sorted(Comparator.comparing(RecentSearch::getDateTime).reversed())
+                .limit(Math.min(recentSearches.size(),3))
+                .toList();
+        return UserFindSearchStationsResponse.from(limitedRecentSearches);
     }
 
     public void deleteSearchStationsUser(long userId) {

--- a/src/main/java/backend/sumnail/global/config/WebConfig.java
+++ b/src/main/java/backend/sumnail/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package backend.sumnail.global.config;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedHeaders("*")
+                .allowedMethods("*");
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #46 

## 📌 작업 내용

- 이전 이슈에서, 검색 기록 추가 서비스 및 레포지토리 단이 구현이 완료되어 있었고, 그 로직 자체를 새로운 API 에서 작동하도록 구현했습니다.
- 추가로, 새 API에 대한 명세서와 컨트롤러단을 구현했습니다.
- 회의때 논의되었던 최근 검색 기록에 대해서, 최근 검색 순으로 정렬한 후 3개까지만 검색 기록이 반환되도록 로직을 변경했습니다.
- CORS 세팅을 추가했습니다!

## 🧪 테스트 방법

## ✅ 궁금한 점 & 리뷰 포인트



